### PR TITLE
* Fixed a bug where resizing the window would clear spelling errors.

### DIFF
--- a/Wordsmith/Gui/ScratchPadHelpUI.cs
+++ b/Wordsmith/Gui/ScratchPadHelpUI.cs
@@ -18,9 +18,6 @@ namespace Wordsmith.Gui
         }
         public override void Draw()
         {
-            if (ImGui.Button("ChangeName##ChangeNameButton"))
-                this.WindowName = "New Window Name.";
-
             if (ImGui.BeginTabBar($"{Wordsmith.AppName}HelpTabBar"))
             {
                 // General tab.


### PR DESCRIPTION
* Put everything below the errors into a child widget to auto-sizing.

* Made the Text->Clear menu item become Text->Undo Clear when text has been cleared.

* Removed the "Change Name" button from the help UI.